### PR TITLE
Added an entry for NCII dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ This dataset contains an Year wise Record of flood damage in India! It might hel
  
 * [CAIT Indonesia Climate Data Explorer (PINDAI)](https://datasets.wri.org/dataset/cait-indonesia-climate-data-explorer-pindai-data) The Indonesia Climate Data Explorer (PINDAI), an open online platform featuring Indonesian national and provincial level climate policy information and data, including historical and projected emissions, climate actions and development plans.
 
-
+* [National Centers for Environmental Information](https://www.ncdc.noaa.gov/cdo-web/datasets) NOAA's National Centers for Environmental Information (NCEI) is responsible for preserving, monitoring, assessing, and providing public access to the Nation's treasure of climate and historical weather data and information.


### PR DESCRIPTION
NOAA's National Centers for Environmental Information (NCEI) is responsible for preserving, monitoring, assessing, and providing public access to the Nation's treasure of climate and historical weather data and information.